### PR TITLE
도메인 생성 및 기본 CR 구현

### DIFF
--- a/src/main/java/com/gk_board/GkBoardApplication.java
+++ b/src/main/java/com/gk_board/GkBoardApplication.java
@@ -2,7 +2,9 @@ package com.gk_board;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class GkBoardApplication {
 

--- a/src/main/java/com/gk_board/article/config/JpaConfig.java
+++ b/src/main/java/com/gk_board/article/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package com.gk_board.article.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}

--- a/src/main/java/com/gk_board/article/controller/ArticleController.java
+++ b/src/main/java/com/gk_board/article/controller/ArticleController.java
@@ -1,0 +1,45 @@
+package com.gk_board.article.controller;
+
+import com.gk_board.article.dto.ArticleDto;
+import com.gk_board.article.dto.request.ArticleRequestDto;
+import com.gk_board.article.dto.response.ArticleListResponse;
+import com.gk_board.article.service.ArticleService;
+import com.gk_board.global.response.PageResponseDto;
+import com.gk_board.global.response.SingleResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/articles")
+@RestController
+public class ArticleController {
+    private final ArticleService articleService;
+
+    @GetMapping
+    public ResponseEntity readArticleList(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)Pageable pageable
+            ){
+        Page<ArticleListResponse> articlePage = articleService.getArticlesList(pageable).map(ArticleListResponse::from);
+        List<ArticleListResponse> articleList = articlePage.getContent();
+        return new ResponseEntity<>(
+                new PageResponseDto<>(articleList,articlePage),HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity createArticle(
+            @RequestBody ArticleRequestDto articleRequestDto){
+
+        ArticleDto articleDto = articleService.saveArticle(articleRequestDto.toDto());
+
+        return new ResponseEntity(
+                new SingleResponseDto<>(articleDto), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/gk_board/article/dto/ArticleDto.java
+++ b/src/main/java/com/gk_board/article/dto/ArticleDto.java
@@ -1,0 +1,35 @@
+package com.gk_board.article.dto;
+
+import com.gk_board.article.entity.Article;
+
+import java.time.LocalDateTime;
+
+public record ArticleDto(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+
+) {
+    public static ArticleDto of(String title, String content){
+        return new ArticleDto(null, title, content, null, null);
+    }
+
+    public static ArticleDto from(Article entity){
+        return new ArticleDto(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        );
+    }
+
+    public Article toEntity(){
+        return Article.of(
+                title,
+                content
+        );
+    }
+}

--- a/src/main/java/com/gk_board/article/dto/request/ArticleRequestDto.java
+++ b/src/main/java/com/gk_board/article/dto/request/ArticleRequestDto.java
@@ -1,0 +1,20 @@
+package com.gk_board.article.dto.request;
+
+import com.gk_board.article.dto.ArticleDto;
+
+public record ArticleRequestDto(
+        Long articleId,
+        String title,
+        String content
+) {
+    public static ArticleRequestDto of (Long articleId, String title, String content){
+        return new ArticleRequestDto(articleId, title, content);
+    }
+
+    public ArticleDto toDto(){
+        return ArticleDto.of(
+                title,
+                content
+        );
+    }
+}

--- a/src/main/java/com/gk_board/article/dto/response/ArticleListResponse.java
+++ b/src/main/java/com/gk_board/article/dto/response/ArticleListResponse.java
@@ -1,0 +1,23 @@
+package com.gk_board.article.dto.response;
+
+import com.gk_board.article.dto.ArticleDto;
+
+import java.time.LocalDateTime;
+
+public record ArticleListResponse(
+        Long articleId,
+        String title,
+        LocalDateTime createdAt
+) {
+    public static ArticleListResponse of (Long articleId, String title, LocalDateTime createdAt){
+        return new ArticleListResponse(articleId, title, createdAt);
+    }
+
+    public static ArticleListResponse from(ArticleDto dto){
+        return new ArticleListResponse(
+                dto.id(),
+                dto.title(),
+                dto.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/gk_board/article/entity/Article.java
+++ b/src/main/java/com/gk_board/article/entity/Article.java
@@ -1,0 +1,35 @@
+package com.gk_board.article.entity;
+
+import com.gk_board.global.AuditingFields;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.Map;
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Article extends AuditingFields {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+    @Column(nullable = false, length = 10000)
+    private String content;
+
+    @ElementCollection
+    private Map<Integer,Integer> refArticle;
+
+    public Article(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+
+    public static Article of(String title, String content) {
+        return new Article(title, content);
+    }
+}

--- a/src/main/java/com/gk_board/article/repository/ArticleRepository.java
+++ b/src/main/java/com/gk_board/article/repository/ArticleRepository.java
@@ -1,0 +1,10 @@
+package com.gk_board.article.repository;
+
+import com.gk_board.article.entity.Article;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+    Page<Article> findAll(Pageable pageable);
+}

--- a/src/main/java/com/gk_board/article/service/ArticleService.java
+++ b/src/main/java/com/gk_board/article/service/ArticleService.java
@@ -1,0 +1,12 @@
+package com.gk_board.article.service;
+
+import com.gk_board.article.dto.ArticleDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ArticleService {
+    //게시물 작성
+    ArticleDto saveArticle(ArticleDto dto);
+
+    Page<ArticleDto> getArticlesList(Pageable pageable);
+}

--- a/src/main/java/com/gk_board/article/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/gk_board/article/service/impl/ArticleServiceImpl.java
@@ -1,0 +1,34 @@
+package com.gk_board.article.service.impl;
+
+import com.gk_board.article.dto.ArticleDto;
+import com.gk_board.article.repository.ArticleRepository;
+import com.gk_board.article.service.ArticleService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ArticleServiceImpl implements ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    //게시물 작성
+    @Override
+    public ArticleDto saveArticle(ArticleDto dto){
+
+        ArticleDto articleDto = ArticleDto.from(articleRepository.save(dto.toEntity()));
+        return articleDto;
+    }
+
+    @Override
+    public Page<ArticleDto> getArticlesList(Pageable pageable){
+        Page<ArticleDto> articleList = articleRepository.findAll(pageable).map(ArticleDto::from);
+        return articleList;
+    }
+
+
+}

--- a/src/main/java/com/gk_board/global/AuditingFields.java
+++ b/src/main/java/com/gk_board/global/AuditingFields.java
@@ -1,0 +1,34 @@
+package com.gk_board.global;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt; //수정일시
+
+
+}

--- a/src/main/java/com/gk_board/global/response/PageInfo.java
+++ b/src/main/java/com/gk_board/global/response/PageInfo.java
@@ -1,0 +1,13 @@
+package com.gk_board.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PageInfo {
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+}

--- a/src/main/java/com/gk_board/global/response/PageResponseDto.java
+++ b/src/main/java/com/gk_board/global/response/PageResponseDto.java
@@ -1,0 +1,26 @@
+package com.gk_board.global.response;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class PageResponseDto<T> {
+    private List<T> data;
+    private PageInfo pageInfo;
+    private List<Integer> barNumber;
+
+    public PageResponseDto(List<T> data, Page page, List<Integer> barNumber) {
+        this.data = data;
+        this.pageInfo = new PageInfo(page.getNumber() + 1,
+                page.getSize(), page.getTotalElements(), page.getTotalPages());
+        this.barNumber = barNumber;
+    }
+
+    public PageResponseDto(List<T> data, Page page){
+        this.data = data;
+        this.pageInfo = new PageInfo(page.getNumber() + 1,
+                page.getSize(), page.getTotalElements(), page.getTotalPages());
+    }
+}

--- a/src/main/java/com/gk_board/global/response/SingleResponseDto.java
+++ b/src/main/java/com/gk_board/global/response/SingleResponseDto.java
@@ -1,0 +1,10 @@
+package com.gk_board.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SingleResponseDto<T> {
+    private T data;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,1 +1,20 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2
+  datasource:
+    url: jdbc:h2:mem:test
+    driver-class-name: org.h2.Driver
 
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    defer-datasource-initialization: true
+  sql:
+    init:
+      data-locations: classpath*:data.sql

--- a/src/test/java/com/gk_board/GkBoardApplicationTests.java
+++ b/src/test/java/com/gk_board/GkBoardApplicationTests.java
@@ -1,4 +1,4 @@
-package com.example.gk_board;
+package com.gk_board;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
#1  에서 해야할 구현 완료

`Article` 도메인에 대한 기본 명세 충족

- 게시판은 게시글의 ID, 제목, 본문 생성 날짜로 구성 , 제목과 본문은 각각 텍스트 (varchar)
- 게시글 목록은 게시글 제목과 날짜정보를 가져옴
