### PR TITLE
연관 게시글 로직 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,35 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // queryDSL 설정
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    implementation "com.querydsl:querydsl-core"
+    implementation "com.querydsl:querydsl-collections"
+    //querydsl JPAAnnotationProcess
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    // java.lang.NoClassDefFoundError (javax.annotation.Generated) 대응코드
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    // java.lang.NoClassDefFoundError (javax.annotation.Entity) 대응코드
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gk_board/article/controller/ArticleController.java
+++ b/src/main/java/com/gk_board/article/controller/ArticleController.java
@@ -3,9 +3,12 @@ package com.gk_board.article.controller;
 import com.gk_board.article.dto.ArticleDto;
 import com.gk_board.article.dto.request.ArticleRequestDto;
 import com.gk_board.article.dto.response.ArticleListResponse;
+import com.gk_board.article.dto.response.ArticleResponse;
 import com.gk_board.article.service.ArticleService;
+import com.gk_board.article.service.impl.RefServiceImpl;
 import com.gk_board.global.response.PageResponseDto;
 import com.gk_board.global.response.SingleResponseDto;
+import jakarta.persistence.GeneratedValue;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,22 +25,47 @@ import java.util.List;
 @RestController
 public class ArticleController {
     private final ArticleService articleService;
+    private final RefServiceImpl refService;
 
+    //게시글 리스트
     @GetMapping
     public ResponseEntity readArticleList(
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)Pageable pageable
-            ){
+            @PageableDefault(size = 10, sort = "created_at", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
         Page<ArticleListResponse> articlePage = articleService.getArticlesList(pageable).map(ArticleListResponse::from);
         List<ArticleListResponse> articleList = articlePage.getContent();
         return new ResponseEntity<>(
-                new PageResponseDto<>(articleList,articlePage),HttpStatus.OK);
+                new PageResponseDto<>(articleList, articlePage), HttpStatus.OK);
     }
+
+    //게시글 단건
+    @GetMapping("/{article-id}")
+    public ResponseEntity readArticle(
+            @PathVariable("article-id") Long articleId) {
+
+        ArticleResponse articleResponse = articleService.getArticle(articleId);
+
+        return new ResponseEntity<>(
+                new SingleResponseDto<>(articleResponse), HttpStatus.OK
+        );
+    }
+
 
     @PostMapping
     public ResponseEntity createArticle(
-            @RequestBody ArticleRequestDto articleRequestDto){
+            @RequestBody ArticleRequestDto articleRequestDto) {
 
+        //게시글 저장
         ArticleDto articleDto = articleService.saveArticle(articleRequestDto.toDto());
+
+        //게시글 본문을 조각화 하여 연관 게시글 저장
+        refService.saveArticleToWord(articleDto.id());
+
+        List<String> refKeyword = refService.getArticleKeyword(articleDto.id()).stream().toList();
+
+        if(refKeyword.size()>1) {
+            articleService.saveRefArticle(articleDto.id(), refKeyword);
+        }
 
         return new ResponseEntity(
                 new SingleResponseDto<>(articleDto), HttpStatus.CREATED);

--- a/src/main/java/com/gk_board/article/dto/ArticleDto.java
+++ b/src/main/java/com/gk_board/article/dto/ArticleDto.java
@@ -8,7 +8,7 @@ public record ArticleDto(
         Long id,
         String title,
         String content,
-        LocalDateTime createdAt,
+        LocalDateTime created_at,
         LocalDateTime modifiedAt
 
 ) {
@@ -25,6 +25,8 @@ public record ArticleDto(
                 entity.getModifiedAt()
         );
     }
+
+
 
     public Article toEntity(){
         return Article.of(

--- a/src/main/java/com/gk_board/article/dto/response/ArticleListResponse.java
+++ b/src/main/java/com/gk_board/article/dto/response/ArticleListResponse.java
@@ -1,23 +1,32 @@
 package com.gk_board.article.dto.response;
 
 import com.gk_board.article.dto.ArticleDto;
+import com.gk_board.article.entity.Article;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 public record ArticleListResponse(
         Long articleId,
         String title,
-        LocalDateTime createdAt
+        LocalDateTime created_at
 ) {
-    public static ArticleListResponse of (Long articleId, String title, LocalDateTime createdAt){
-        return new ArticleListResponse(articleId, title, createdAt);
+    public static ArticleListResponse of (Long articleId, String title, LocalDateTime created_at){
+        return new ArticleListResponse(articleId, title, created_at);
     }
 
     public static ArticleListResponse from(ArticleDto dto){
         return new ArticleListResponse(
                 dto.id(),
                 dto.title(),
-                dto.createdAt()
+                dto.created_at()
+        );
+    }
+    public static ArticleListResponse from(Article entity){
+        return new ArticleListResponse(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/gk_board/article/dto/response/ArticleResponse.java
+++ b/src/main/java/com/gk_board/article/dto/response/ArticleResponse.java
@@ -1,0 +1,34 @@
+package com.gk_board.article.dto.response;
+
+import com.gk_board.article.dto.ArticleDto;
+import com.gk_board.article.entity.Article;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public record ArticleResponse(
+        Long articleId,
+        String title,
+        String content,
+        LocalDateTime created_at,
+        List<ArticleDto> refArticles
+) {
+    public static ArticleResponse of (Long articleId, String title,String content, LocalDateTime created_at, List<ArticleDto> refArticles){
+        return new ArticleResponse(articleId, title, content, created_at,refArticles);
+    }
+
+
+    public static ArticleResponse from(Article entity){
+        return new ArticleResponse(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getRefArticle().stream()
+                        .map(ArticleDto::from)
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/com/gk_board/article/entity/Article.java
+++ b/src/main/java/com/gk_board/article/entity/Article.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
 import java.util.Map;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -20,14 +23,19 @@ public class Article extends AuditingFields {
     @Column(nullable = false, length = 10000)
     private String content;
 
-    @ElementCollection
-    private Map<Integer,Integer> refArticle;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mainArticle")
+    @Setter
+    private Article mainArticle;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "mainArticle")
+    @Setter
+    private List<Article> refArticle;
 
     public Article(String title, String content) {
         this.title = title;
         this.content = content;
     }
-
 
     public static Article of(String title, String content) {
         return new Article(title, content);

--- a/src/main/java/com/gk_board/article/entity/Keyword.java
+++ b/src/main/java/com/gk_board/article/entity/Keyword.java
@@ -1,0 +1,32 @@
+package com.gk_board.article.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Keyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column
+    private Long articleId;
+
+    @Column
+    private String refKeyword;
+
+
+    public Keyword(Long articleId, String refKeyword) {
+        this.articleId = articleId;
+        this.refKeyword = refKeyword;
+
+    }
+
+    public static Keyword of(Long articleId, String keyword){
+        return new Keyword(articleId, keyword);
+    }
+}

--- a/src/main/java/com/gk_board/article/repository/ArticleRepository.java
+++ b/src/main/java/com/gk_board/article/repository/ArticleRepository.java
@@ -4,7 +4,15 @@ import com.gk_board.article.entity.Article;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
     Page<Article> findAll(Pageable pageable);
+
+    Long countArticleByContentContaining(String keyword);
+
+    @Query("select a from Article as a where a.content in :keyword")
+    List<Article> findByContentIn(List<String> keyword);
 }

--- a/src/main/java/com/gk_board/article/repository/KeywordRepository.java
+++ b/src/main/java/com/gk_board/article/repository/KeywordRepository.java
@@ -1,0 +1,19 @@
+package com.gk_board.article.repository;
+
+import com.gk_board.article.entity.Article;
+import com.gk_board.article.entity.Keyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+    Keyword findByRefKeyword(String Keyword);
+
+    Keyword getReferenceByRefKeyword(String keyword);
+
+    List<Keyword> getKeywordsByArticleId(Long articleId);
+
+    @Query("select k from Keyword as k where k.refKeyword in :keyword")
+    List<Keyword> findByContentIn(List<String> keyword);
+}

--- a/src/main/java/com/gk_board/article/repository/querydsl/KeywordRepositoryCustom.java
+++ b/src/main/java/com/gk_board/article/repository/querydsl/KeywordRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.gk_board.article.repository.querydsl;
+
+import com.gk_board.article.entity.Keyword;
+
+import java.util.List;
+
+public interface KeywordRepositoryCustom {
+    List<Keyword> findAllWithKeyWord(List<String> keyword);
+}

--- a/src/main/java/com/gk_board/article/repository/querydsl/impl/KeywordRepositoryCustomImpl.java
+++ b/src/main/java/com/gk_board/article/repository/querydsl/impl/KeywordRepositoryCustomImpl.java
@@ -1,0 +1,23 @@
+package com.gk_board.article.repository.querydsl.impl;
+
+import com.gk_board.article.entity.Keyword;
+import com.gk_board.article.repository.querydsl.KeywordRepositoryCustom;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+@Slf4j
+public class KeywordRepositoryCustomImpl extends QuerydslRepositorySupport implements KeywordRepositoryCustom {
+
+    public KeywordRepositoryCustomImpl() {
+        super(Keyword.class);
+    }
+
+
+    @Override
+    public List<Keyword> findAllWithKeyWord(List<String> keyword) {
+        return null;
+    }
+}
+

--- a/src/main/java/com/gk_board/article/service/ArticleService.java
+++ b/src/main/java/com/gk_board/article/service/ArticleService.java
@@ -1,12 +1,20 @@
 package com.gk_board.article.service;
 
 import com.gk_board.article.dto.ArticleDto;
+import com.gk_board.article.dto.response.ArticleResponse;
+import com.gk_board.article.entity.Article;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface ArticleService {
     //게시물 작성
     ArticleDto saveArticle(ArticleDto dto);
 
+    ArticleDto saveRefArticle(Long articleId, List<String> keywords);
+
     Page<ArticleDto> getArticlesList(Pageable pageable);
+
+    ArticleResponse getArticle(Long articleId);
 }

--- a/src/main/java/com/gk_board/article/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/gk_board/article/service/impl/ArticleServiceImpl.java
@@ -1,33 +1,83 @@
 package com.gk_board.article.service.impl;
 
 import com.gk_board.article.dto.ArticleDto;
+import com.gk_board.article.dto.response.ArticleResponse;
+import com.gk_board.article.entity.Article;
+import com.gk_board.article.entity.Keyword;
 import com.gk_board.article.repository.ArticleRepository;
+import com.gk_board.article.repository.KeywordRepository;
 import com.gk_board.article.service.ArticleService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 @Service
 public class ArticleServiceImpl implements ArticleService {
 
     private final ArticleRepository articleRepository;
-
+    private final KeywordRepository keywordRepository;
     //게시물 작성
     @Override
     public ArticleDto saveArticle(ArticleDto dto){
 
         ArticleDto articleDto = ArticleDto.from(articleRepository.save(dto.toEntity()));
+
         return articleDto;
     }
 
     @Override
+    public ArticleDto saveRefArticle(Long articleId, List<String> keywords){
+        Article article = articleRepository.getReferenceById(articleId);
+        List<Keyword> articleList = keywordRepository.findByContentIn(keywords);
+
+        //키워드에서 중복을 제거하고 검색
+        Set<Long> refArticleId = new HashSet<>();
+        for(int i = 0; i<articleList.size(); i++) {
+            if(!articleId.equals(articleList.get(i).getArticleId()))
+            refArticleId.add(articleList.get(i).getArticleId());
+        }
+
+        for(int i = 0; i<articleList.size(); i++){
+            if(!articleId.equals(articleList.get(i).getArticleId()))
+                article = articleRepository.getReferenceById(articleList.get(i).getArticleId());
+            article.setMainArticle(articleRepository.getReferenceById(articleId));
+        }
+
+
+
+//        List<Article> articleDtoList = new ArrayList<>();
+//        for (Long aLong : refArticleId) {
+//            articleDtoList.add(articleRepository.getReferenceById(aLong));
+//        }
+//
+//        article.setRefArticle(articleDtoList);
+        List<ArticleDto> checkArticle = articleRepository.findById(articleId).map(ArticleDto::from).stream().toList();
+
+
+        log.info("아티클 확인: {} , 아티클 리스트 확인 : {}, 연관 아티클 Id: {} , 연관 아티클 확인 : {}", article.getContent(),articleList,refArticleId, checkArticle );
+
+        return null;
+    }
+
+
+    @Override
     public Page<ArticleDto> getArticlesList(Pageable pageable){
-        Page<ArticleDto> articleList = articleRepository.findAll(pageable).map(ArticleDto::from);
-        return articleList;
+        return articleRepository.findAll(pageable).map(ArticleDto::from);
+    }
+
+    @Override
+    public ArticleResponse getArticle(Long articleId){
+        Article article = articleRepository.getReferenceById(articleId);
+        return ArticleResponse.from(article);
     }
 
 

--- a/src/main/java/com/gk_board/article/service/impl/RefServiceImpl.java
+++ b/src/main/java/com/gk_board/article/service/impl/RefServiceImpl.java
@@ -1,0 +1,62 @@
+package com.gk_board.article.service.impl;
+
+import com.gk_board.article.entity.Article;
+import com.gk_board.article.entity.Keyword;
+import com.gk_board.article.repository.ArticleRepository;
+import com.gk_board.article.repository.KeywordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RefServiceImpl {
+
+    private final ArticleRepository articleRepository;
+    private final KeywordRepository keywordRepository;
+
+
+    //본문 조각화 키워드 저장
+    public List<String> saveArticleToWord(Long articleId) {
+        Article article = articleRepository.getReferenceById(articleId);
+        List<String> arr = Arrays.stream(article.getContent().split(" "))
+                .sorted()
+                .collect(Collectors.toList());
+
+        log.info("keyword: {}", arr);
+
+        for (int i = 0; i < arr.size(); i++) {
+            keywordRepository.save(new Keyword(articleId, arr.get(i)));
+
+        }
+        
+        return arr;
+    }
+
+    public Set<String> getArticleKeyword(Long articleId) {
+        List<Keyword> keywordList = keywordRepository.getKeywordsByArticleId(articleId);
+        Set<String> refKeyword = new HashSet<>();
+        long allArticle = articleRepository.count();
+
+        for (int i = 0; i < keywordList.size(); i++) {
+            int cnt = 0;
+            float ratio = 0;
+            long keywordRatio = articleRepository.countArticleByContentContaining(keywordList.get(i).getRefKeyword());
+
+            if ((float) keywordRatio / allArticle < 0.4) {
+                refKeyword.add(keywordList.get(i).getRefKeyword());
+                ratio = (float) keywordRatio / allArticle;
+
+            }
+            log.info(" 전체 게시글 : {}, 현재 키워드 {}, 키워드 비율 : {}", allArticle,keywordList.get(i).getRefKeyword(), ratio);
+        }
+        log.info("keyword 리스트 : {}", refKeyword);
+
+        return refKeyword;
+    }
+
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,598 @@
+insert into ARTICLE (title, content, created_at, modified_at) values ('Cinderfella', 'In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.
+
+Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.', '2022-12-10', '2022-11-05');
+insert into ARTICLE (title, content, created_at, modified_at) values ('The Challenge', 'Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.', '2023-04-16', '2022-05-01');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Back to the Future Part III', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.', '2023-01-28', '2022-06-14');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Kung Fu Panda Holiday Special', 'Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.
+
+In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.
+
+Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.', '2022-11-06', '2022-05-08');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Temptation of St. Tony, The (Püha Tõnu kiusamine)', 'Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque.', '2022-07-21', '2022-08-19');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Next Best Thing, The', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.', '2023-04-23', '2022-08-02');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Designated Mourner, The', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.', '2022-09-28', '2022-09-09');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Seven Chances', 'Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.
+
+Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.', '2023-02-05', '2022-07-03');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Accidental Spy, The (Dak miu mai shing)', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.
+
+Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.', '2022-12-18', '2022-09-05');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Perfect Man, The', 'Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.
+
+Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.', '2022-06-19', '2022-08-27');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Death Note', 'Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.', '2022-12-18', '2022-09-11');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Big Squeeze, The', 'Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.
+
+Sed ante. Vivamus tortor. Duis mattis egestas metus.', '2022-05-20', '2022-09-06');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Whale Rider', 'In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.
+
+Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.
+
+Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque.', '2022-06-22', '2023-04-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Year One, The (L''an 01)', 'Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.', '2022-06-13', '2022-10-24');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Blues Harp', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.', '2022-06-28', '2023-02-25');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Game of Werewolves', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.
+
+In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.', '2022-06-15', '2022-12-14');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Did You Hear About the Morgans?', 'Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.', '2022-11-28', '2022-12-04');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Bridal Party in Hardanger, The (Brudeferden i Hardanger)', 'Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.
+
+Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.', '2022-10-15', '2022-08-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Jimmy Rosenberg: The Father, the Son & the Talent', 'Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.
+
+Sed ante. Vivamus tortor. Duis mattis egestas metus.', '2022-04-30', '2022-11-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Transformers: Revenge of the Fallen', 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.
+
+Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.', '2022-07-08', '2022-06-18');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Twelve O''Clock High', 'Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.
+
+Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.
+
+Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.', '2023-04-13', '2022-08-25');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Welcome to Sarajevo', 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Proin risus. Praesent lectus.', '2023-04-07', '2022-06-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Look, Up in the Sky! The Amazing Story of Superman', 'Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.
+
+Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.', '2022-06-20', '2022-06-28');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Leonard Part 6', 'Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.
+
+Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.', '2023-01-06', '2022-10-15');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Whom the Gods Wish to Destroy (Nibelungen, Teil 1: Siegfried, Die)', 'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.
+
+Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', '2023-02-02', '2022-12-14');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Escaflowne: The Movie (Escaflowne)', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.', '2022-06-30', '2022-08-09');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Curdled', 'Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.', '2022-07-25', '2022-12-13');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Trailer Park Boys: Live at the North Pole', 'In quis justo. Maecenas rhoncus aliquam lacus. Morbi quis tortor id nulla ultrices aliquet.', '2022-07-29', '2023-03-08');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Double Trouble', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.', '2022-06-04', '2022-09-15');
+insert into ARTICLE (title, content, created_at, modified_at) values ('General Died at Dawn, The', 'In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.', '2022-11-09', '2022-12-17');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Desert of Forbidden Art, The', 'Sed ante. Vivamus tortor. Duis mattis egestas metus.
+
+Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.
+
+Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.', '2023-02-24', '2022-07-28');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Bartok the Magnificent', 'Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.', '2022-12-08', '2023-04-12');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Warm December, A', 'Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.', '2023-03-27', '2022-10-02');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Pocketful of Miracles', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.
+
+Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.', '2023-04-08', '2023-02-03');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Visitors', 'In congue. Etiam justo. Etiam pretium iaculis justo.
+
+In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.
+
+Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.', '2022-08-25', '2022-05-30');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Trash', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.', '2022-09-13', '2023-02-17');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Lovely, Still', 'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.
+
+Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.
+
+Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.', '2022-04-30', '2023-01-02');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Mutual Appreciation', 'Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.', '2023-03-26', '2022-12-26');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Visit, The', 'Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.', '2022-12-30', '2022-11-07');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Faster Pussycat! Kill! Kill!', 'Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.
+
+Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque.
+
+Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus.', '2022-07-16', '2022-08-09');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Glass Key, The', 'Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.', '2022-08-31', '2022-10-01');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Time of Peace (Tempos de Paz)', 'Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.', '2022-09-22', '2023-04-16');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Paranormal Activity', 'Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.', '2022-09-15', '2023-03-18');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Thieves, The (Dodookdeul)', 'Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.
+
+Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.', '2023-04-04', '2023-02-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Other Side of the Bed, The (Otro lado de la cama, El)', 'Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.', '2023-03-17', '2022-10-29');
+insert into ARTICLE (title, content, created_at, modified_at) values ('House III: The Horror Show', 'Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', '2022-10-09', '2022-12-31');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Traitor', 'Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.
+
+Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio.
+
+Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.', '2022-11-17', '2022-05-24');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Opening Night', 'Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.', '2023-01-23', '2023-01-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Shadow People', 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.
+
+Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.
+
+Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.', '2023-04-02', '2023-02-09');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Deadline', 'Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.
+
+Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.
+
+Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh.', '2022-04-29', '2022-09-21');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Lizzie McGuire Movie, The', 'In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.', '2022-10-09', '2022-09-14');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Urban Legends: Bloody Mary', 'In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.
+
+Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.', '2022-04-29', '2022-10-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Dementia 13', 'Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.
+
+Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.
+
+Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.', '2022-12-28', '2023-01-28');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Night of the Running Man', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.', '2022-10-20', '2022-08-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Rough House, The', 'Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.
+
+Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.', '2022-11-30', '2022-12-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Nurse 3D', 'Proin leo odio, porttitor id, consequat in, consequat ut, nulla. Sed accumsan felis. Ut at dolor quis odio consequat varius.
+
+Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.
+
+Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.', '2022-11-11', '2022-06-06');
+insert into ARTICLE (title, content, created_at, modified_at) values ('World''s Greatest Athlete, The', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.
+
+Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.
+
+Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.', '2022-12-09', '2022-05-12');
+insert into ARTICLE (title, content, created_at, modified_at) values ('The Baker''s Wife', 'Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.', '2022-10-27', '2023-02-13');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Lay the Favorite', 'Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.
+
+Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.', '2022-08-10', '2022-05-26');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Immortal Sergeant', 'In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.', '2022-07-24', '2023-01-27');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Plymouth Adventure', 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.
+
+Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.', '2022-11-18', '2022-10-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Ricky & Barabba', 'Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.
+
+Fusce consequat. Nulla nisl. Nunc nisl.', '2023-04-26', '2023-03-07');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Family Affair ', 'Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.', '2022-08-14', '2023-04-05');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Long Ships, The', 'Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.
+
+In congue. Etiam justo. Etiam pretium iaculis justo.
+
+In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.', '2023-02-08', '2023-03-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Wavelength', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.
+
+Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.', '2022-05-01', '2022-11-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Less Than Zero', 'Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.', '2022-08-20', '2022-09-17');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Imaginary Witness: Hollywood and the Holocaust ', 'Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.
+
+In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.
+
+Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.', '2022-05-27', '2023-04-13');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Simon', 'Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio.
+
+Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.', '2022-12-20', '2022-06-29');
+insert into ARTICLE (title, content, created_at, modified_at) values ('How to Make Money Selling Drugs', 'Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.', '2022-09-21', '2023-03-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Get on Up', 'Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.', '2022-08-14', '2023-01-24');
+insert into ARTICLE (title, content, created_at, modified_at) values ('First Shot', 'Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.
+
+Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.
+
+Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.', '2022-06-28', '2022-08-14');
+insert into ARTICLE (title, content, created_at, modified_at) values ('I''m Gonna Explode (a.k.a. I''m Going to Explode) (Voy a explotar)', 'Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.', '2023-01-24', '2022-06-18');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Ricky Gervais Live: Animals', 'In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.
+
+Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.
+
+Sed ante. Vivamus tortor. Duis mattis egestas metus.', '2022-08-28', '2023-01-24');
+insert into ARTICLE (title, content, created_at, modified_at) values ('End of the Line', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.', '2023-04-04', '2023-01-27');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Inheritance, The (Karami-ai)', 'Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.
+
+Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.
+
+Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.', '2022-10-27', '2023-03-30');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Werner - Beinhart!', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.
+
+Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.', '2023-02-03', '2023-04-08');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Lawless Breed, The', 'In congue. Etiam justo. Etiam pretium iaculis justo.', '2022-09-01', '2023-03-31');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Whity', 'In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.
+
+Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.
+
+Sed ante. Vivamus tortor. Duis mattis egestas metus.', '2023-01-22', '2022-06-12');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Inkheart', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.', '2022-05-20', '2022-08-10');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Game of Death II (a.k.a. Tower of Death) (Si wang ta)', 'Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.
+
+Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.
+
+Curabitur at ipsum ac tellus semper interdum. Mauris ullamcorper purus sit amet nulla. Quisque arcu libero, rutrum ac, lobortis vel, dapibus at, diam.', '2023-04-12', '2022-09-09');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Sea Wolves, The', 'Sed ante. Vivamus tortor. Duis mattis egestas metus.
+
+Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.
+
+Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.', '2023-03-21', '2022-07-05');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Rouva presidentti', 'Fusce consequat. Nulla nisl. Nunc nisl.
+
+Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.
+
+In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.', '2022-05-27', '2023-02-05');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Shottas', 'Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.
+
+Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.
+
+Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.', '2023-03-06', '2022-05-04');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Jack Strong', 'Fusce consequat. Nulla nisl. Nunc nisl.', '2022-12-01', '2022-07-05');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Tropical Fish (Re dai yu)', 'Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus.', '2022-07-15', '2022-06-26');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Zero Hour!', 'Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.
+
+Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.
+
+Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.', '2022-11-07', '2023-03-01');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Northfork', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.
+
+Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.', '2022-09-28', '2023-01-25');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Appleseed (Appurushîdo)', 'Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.
+
+Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.', '2023-01-10', '2022-07-06');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Redacted', 'Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque.', '2022-08-15', '2023-02-10');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Gold Rush, The', 'In quis justo. Maecenas rhoncus aliquam lacus. Morbi quis tortor id nulla ultrices aliquet.', '2023-03-04', '2023-04-11');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Ring Finger, The (L''annulaire)', 'Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.', '2022-06-26', '2023-03-14');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Restless (Uro)', 'Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.', '2022-06-20', '2022-12-17');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Beaver Trilogy Part IV', 'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.', '2022-12-23', '2023-02-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Household Saints', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.
+
+Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.', '2022-12-11', '2022-10-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Storm in Summer, A', 'Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', '2022-08-16', '2023-04-13');
+insert into ARTICLE (title, content, created_at, modified_at) values ('7 Dollars on the Red (Sette dollari sul rosso)', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.', '2023-04-19', '2022-09-25');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Sebastian Maniscalco: What''s Wrong with People?', 'Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.
+
+Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.', '2023-02-01', '2023-04-01');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Facing the Truth (At kende sandheden)', 'Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.
+
+Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.', '2022-06-18', '2022-06-25');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Amos & Andrew', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.', '2022-08-19', '2022-09-25');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Nine Lives', 'Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.', '2023-04-24', '2023-04-19');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Vengeance (Fuk sau)', 'Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.', '2022-10-14', '2022-05-02');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Chinese Take-Out (Chinese Take-Away) (Un cuento chino)', 'In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.
+
+Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.', '2022-04-28', '2023-04-13');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Hollywoodland', 'Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.
+
+Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.', '2022-11-06', '2023-02-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Hellboy', 'Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.
+
+Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.', '2022-07-07', '2022-09-03');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Warrendale', 'Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.', '2022-08-24', '2022-12-09');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Mr. Denning Drives North', 'Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.', '2022-06-08', '2022-08-27');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Reconstituirea (Reconstruction)', 'Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.
+
+Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.
+
+Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.', '2023-02-02', '2022-07-01');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Shadrach', 'Phasellus in felis. Donec semper sapien a libero. Nam dui.', '2023-02-08', '2023-04-19');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Other Girls', 'Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.', '2022-07-03', '2022-06-05');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Johnny Express', 'Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.
+
+Curabitur at ipsum ac tellus semper interdum. Mauris ullamcorper purus sit amet nulla. Quisque arcu libero, rutrum ac, lobortis vel, dapibus at, diam.', '2022-06-10', '2022-09-01');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Role/Play', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.
+
+In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.', '2023-01-21', '2022-12-06');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Free Soul, A', 'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.
+
+Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.
+
+Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.', '2023-01-27', '2022-07-26');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Russendisko', 'Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.
+
+Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.
+
+Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.', '2022-10-29', '2023-01-09');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Wild Grass (Herbes folles, Les)', 'Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.', '2022-09-09', '2022-08-18');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Brewster''s Millions', 'Proin leo odio, porttitor id, consequat in, consequat ut, nulla. Sed accumsan felis. Ut at dolor quis odio consequat varius.
+
+Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.', '2022-07-30', '2023-03-12');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Four Feathers, The', 'In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.
+
+Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.', '2022-07-22', '2022-11-29');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Monkey in Winter, A (Un singe en hiver)', 'Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.
+
+Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.', '2023-03-01', '2022-08-25');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Captains Courageous', 'Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio.
+
+Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.', '2022-05-21', '2022-12-18');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Dead Pool, The', 'Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.
+
+Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.', '2022-11-19', '2022-06-17');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Comic-Con Episode IV: A Fan''s Hope', 'In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.
+
+Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.', '2023-01-07', '2023-03-08');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Late Spring (Banshun)', 'Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.
+
+Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.
+
+Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.', '2023-03-07', '2022-07-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Exterminating Angels, The (anges exterminateurs, Les)', 'Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.', '2022-11-17', '2022-09-26');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Ice Princess', 'In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.
+
+Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.', '2023-01-25', '2023-01-11');
+insert into ARTICLE (title, content, created_at, modified_at) values ('First Snow', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.', '2022-10-25', '2022-12-19');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Dreamcatcher', 'Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque.
+
+Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus.', '2022-06-29', '2022-11-21');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Silent One, The', 'Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.
+
+In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.
+
+Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.', '2022-06-30', '2022-10-31');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Class of Nuke ''Em High Part II: Subhumanoid Meltdown', 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.
+
+Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.
+
+Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.', '2023-04-26', '2022-06-30');
+insert into ARTICLE (title, content, created_at, modified_at) values ('One Trick Pony', 'Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.', '2022-06-26', '2022-06-09');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Nadine', 'Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.
+
+Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.', '2022-05-27', '2023-03-02');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Boom!', 'Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio.
+
+Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.', '2023-03-23', '2023-01-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Shakedown', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.
+
+In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.', '2023-01-27', '2022-11-08');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Wooden Man''s Bride, The (Yan shen)', 'In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.', '2023-04-16', '2022-06-23');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Home for Christmas (Hjem til jul)', 'In congue. Etiam justo. Etiam pretium iaculis justo.', '2023-02-04', '2022-07-09');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Swimming Pool, The (La piscine)', 'Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.', '2022-08-29', '2022-10-24');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Unspeakable Act, The', 'Sed ante. Vivamus tortor. Duis mattis egestas metus.
+
+Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.', '2022-06-21', '2022-09-07');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Lie with Me', 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.', '2022-11-20', '2022-09-10');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Cadaver Christmas, A', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.', '2023-03-26', '2022-12-28');
+insert into ARTICLE (title, content, created_at, modified_at) values ('It''s the Easter Beagle, Charlie Brown!', 'Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.
+
+Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.', '2022-08-26', '2023-02-05');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Misadventures of Margaret, The', 'Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh.', '2022-12-30', '2022-11-21');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Final Destination 2', 'Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.
+
+Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.
+
+Curabitur at ipsum ac tellus semper interdum. Mauris ullamcorper purus sit amet nulla. Quisque arcu libero, rutrum ac, lobortis vel, dapibus at, diam.', '2023-04-04', '2022-11-26');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Corn on the Cop', 'Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.', '2022-05-11', '2023-02-27');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Decline of Western Civilization Part II: The Metal Years, The', 'Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.', '2022-07-01', '2022-10-09');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Hello Again', 'Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.', '2023-04-10', '2022-05-03');
+insert into ARTICLE (title, content, created_at, modified_at) values ('I Bury the Living', 'In hac habitasse platea dictumst. Etiam faucibus cursus urna. Ut tellus.
+
+Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.
+
+Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque.', '2022-05-04', '2022-04-27');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Kill Switch', 'Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.
+
+Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.
+
+Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.', '2023-02-28', '2022-05-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Super Mario Bros.', 'Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.
+
+Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.', '2023-03-26', '2022-08-19');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Blood Beast Terror, The', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.', '2022-05-28', '2022-08-18');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Haiku Tunnel', 'Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.
+
+Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.', '2023-01-01', '2022-10-03');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Abbott and Costello in the Foreign Legion', 'Aliquam quis turpis eget elit sodales scelerisque. Mauris sit amet eros. Suspendisse accumsan tortor quis turpis.
+
+Sed ante. Vivamus tortor. Duis mattis egestas metus.
+
+Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.', '2022-11-27', '2023-04-24');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Purge, The', 'Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh.
+
+In quis justo. Maecenas rhoncus aliquam lacus. Morbi quis tortor id nulla ultrices aliquet.
+
+Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.', '2022-05-16', '2022-08-24');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Shower (Xizao)', 'Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.
+
+Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.
+
+Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', '2022-12-22', '2023-01-01');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Trancers', 'Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.
+
+Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.', '2023-04-21', '2022-05-18');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Mondo Cane', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.', '2022-06-30', '2023-03-17');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Sleeping Beauty, The (La belle endormie)', 'Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.', '2023-04-13', '2022-08-12');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Vinyl', 'Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.
+
+Vestibulum ac est lacinia nisi venenatis tristique. Fusce congue, diam id ornare imperdiet, sapien urna pretium nisl, ut volutpat sapien arcu sed augue. Aliquam erat volutpat.
+
+In congue. Etiam justo. Etiam pretium iaculis justo.', '2022-09-08', '2022-05-05');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Master, The', 'Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.', '2022-05-21', '2022-07-23');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Informers, The', 'Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.', '2022-11-04', '2022-07-28');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Guilty of Romance (Koi no tsumi) ', 'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.
+
+Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', '2023-03-06', '2022-06-11');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Season of the Witch (Hungry Wives) (Jack''s Wife)', 'In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.
+
+Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.
+
+Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.', '2022-06-26', '2022-09-21');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Social Network, The', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.', '2023-01-25', '2023-02-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Year of the Horse', 'Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.
+
+Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque.', '2023-03-08', '2023-01-19');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Separation, The (Séparation, La)', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.', '2023-04-13', '2023-04-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('''Neath the Arizona Skies', 'Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.
+
+Fusce consequat. Nulla nisl. Nunc nisl.
+
+Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.', '2022-10-30', '2022-06-28');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Midnight Cowboy', 'Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.
+
+Fusce consequat. Nulla nisl. Nunc nisl.
+
+Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.', '2022-08-07', '2022-10-02');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Borrowers, The', 'Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus.
+
+Phasellus in felis. Donec semper sapien a libero. Nam dui.', '2022-12-24', '2022-06-14');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Speedy', 'Proin eu mi. Nulla ac enim. In tempor, turpis nec euismod scelerisque, quam turpis adipiscing lorem, vitae mattis nibh ligula nec sem.', '2023-03-14', '2023-03-06');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Young and the Damned, The (Olvidados, Los)', 'Praesent blandit. Nam nulla. Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede.
+
+Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus. In est risus, auctor sed, tristique in, tempus sit amet, sem.
+
+Fusce consequat. Nulla nisl. Nunc nisl.', '2023-01-25', '2023-04-18');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Play It Again, Sam', 'Aenean fermentum. Donec ut mauris eget massa tempor convallis. Nulla neque libero, convallis eget, eleifend luctus, ultricies eu, nibh.
+
+Quisque id justo sit amet sapien dignissim vestibulum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nulla dapibus dolor vel est. Donec odio justo, sollicitudin ut, suscipit a, feugiat et, eros.', '2022-09-11', '2022-09-25');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Nutty Professor, The', 'Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.
+
+Nullam porttitor lacus at turpis. Donec posuere metus vitae ipsum. Aliquam non mauris.
+
+Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.', '2022-11-14', '2022-10-31');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Blind Justice (Hævnens nat)', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.', '2023-03-27', '2022-07-18');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Evilspeak', 'Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.', '2022-07-20', '2023-04-04');
+insert into ARTICLE (title, content, created_at, modified_at) values ('10 Questions for the Dalai Lama', 'Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.
+
+Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.
+
+Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.', '2023-02-12', '2023-02-19');
+insert into ARTICLE (title, content, created_at, modified_at) values ('The Story of Robin Hood and His Merrie Men', 'Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+
+Proin interdum mauris non ligula pellentesque ultrices. Phasellus id sapien in sapien iaculis congue. Vivamus metus arcu, adipiscing molestie, hendrerit at, vulputate vitae, nisl.', '2022-12-29', '2022-07-23');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Murder on the Orient Express', 'Fusce consequat. Nulla nisl. Nunc nisl.
+
+Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.', '2022-09-24', '2022-06-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Family Honeymoon', 'Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.
+
+Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.', '2022-08-17', '2023-01-04');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Verbo', 'Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.', '2022-07-30', '2022-12-07');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Blood Ties', 'Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.', '2022-08-02', '2022-07-08');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Blade: Trinity', 'Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.', '2022-10-11', '2022-09-24');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Quartet', 'Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.
+
+Maecenas tristique, est et tempus semper, est quam pharetra magna, ac consequat metus sapien ut nunc. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris viverra diam vitae quam. Suspendisse potenti.', '2023-03-16', '2022-07-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Sword and the Sorcerer, The', 'Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.
+
+Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.
+
+Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.', '2022-10-04', '2023-04-01');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Crisis', 'Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.
+
+Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', '2023-03-28', '2022-06-10');
+insert into ARTICLE (title, content, created_at, modified_at) values ('WW III: World War III (Der 3. Weltkrieg)', 'Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.
+
+Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.
+
+Integer tincidunt ante vel ipsum. Praesent blandit lacinia erat. Vestibulum sed magna at nunc commodo placerat.', '2023-03-12', '2022-12-09');
+insert into ARTICLE (title, content, created_at, modified_at) values ('L''antisémite', 'Praesent id massa id nisl venenatis lacinia. Aenean sit amet justo. Morbi ut odio.', '2022-12-28', '2022-07-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Deterrence', 'Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh.
+
+In quis justo. Maecenas rhoncus aliquam lacus. Morbi quis tortor id nulla ultrices aliquet.
+
+Maecenas leo odio, condimentum id, luctus nec, molestie sed, justo. Pellentesque viverra pede ac diam. Cras pellentesque volutpat dui.', '2022-08-02', '2022-05-02');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Transylmania', 'In congue. Etiam justo. Etiam pretium iaculis justo.', '2022-09-28', '2022-09-24');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Competition, The', 'Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.
+
+In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.', '2022-07-02', '2023-04-11');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Pirates of Penzance, The', 'Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.
+
+Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vivamus vestibulum sagittis sapien. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+
+Etiam vel augue. Vestibulum rutrum rutrum neque. Aenean auctor gravida sem.', '2023-02-18', '2022-07-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Without Bias (a.k.a. Len Bias)', 'Nulla ut erat id mauris vulputate elementum. Nullam varius. Nulla facilisi.
+
+Cras non velit nec nisi vulputate nonummy. Maecenas tincidunt lacus at velit. Vivamus vel nulla eget eros elementum pellentesque.
+
+Quisque porta volutpat erat. Quisque erat eros, viverra eget, congue eget, semper rutrum, nulla. Nunc purus.', '2022-12-28', '2022-07-31');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Blackbird', 'Duis bibendum, felis sed interdum venenatis, turpis enim blandit mi, in porttitor pede justo eu massa. Donec dapibus. Duis at velit eu est congue elementum.
+
+In hac habitasse platea dictumst. Morbi vestibulum, velit id pretium iaculis, diam erat fermentum justo, nec condimentum neque sapien placerat ante. Nulla justo.', '2022-05-11', '2022-11-12');
+insert into ARTICLE (title, content, created_at, modified_at) values ('The Man From The Alamo', 'Suspendisse potenti. In eleifend quam a odio. In hac habitasse platea dictumst.
+
+Maecenas ut massa quis augue luctus tincidunt. Nulla mollis molestie lorem. Quisque ut erat.
+
+Curabitur gravida nisi at nibh. In hac habitasse platea dictumst. Aliquam augue quam, sollicitudin vitae, consectetuer eget, rutrum at, lorem.', '2023-04-07', '2023-01-24');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Island of Dr. Moreau, The', 'Integer ac leo. Pellentesque ultrices mattis odio. Donec vitae nisi.
+
+Nam ultrices, libero non mattis pulvinar, nulla pede ullamcorper augue, a suscipit nulla elit ac nulla. Sed vel enim sit amet nunc viverra dapibus. Nulla suscipit ligula in lacus.', '2023-04-07', '2022-06-07');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Blonde Ice', 'Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.
+
+Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.', '2022-07-15', '2022-10-04');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Apostle, The', 'Duis consequat dui nec nisi volutpat eleifend. Donec ut dolor. Morbi vel lectus in quam fringilla rhoncus.
+
+Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.', '2023-02-02', '2023-03-17');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Wedding Date, The', 'Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.', '2022-10-29', '2022-07-13');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Southern District (Zona Sur)', 'Cras mi pede, malesuada in, imperdiet et, commodo vulputate, justo. In blandit ultrices enim. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.', '2022-10-09', '2023-01-13');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Shake Hands with the Devil', 'Aenean lectus. Pellentesque eget nunc. Donec quis orci eget orci vehicula condimentum.
+
+Curabitur in libero ut massa volutpat convallis. Morbi odio odio, elementum eu, interdum eu, tincidunt in, leo. Maecenas pulvinar lobortis est.
+
+Phasellus sit amet erat. Nulla tempus. Vivamus in felis eu sapien cursus vestibulum.', '2022-07-11', '2022-05-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Diamond Arm, The (Brilliantovaya ruka)', 'In sagittis dui vel nisl. Duis ac nibh. Fusce lacus purus, aliquet at, feugiat non, pretium quis, lectus.', '2022-08-03', '2022-06-20');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Zone 39', 'Duis aliquam convallis nunc. Proin at turpis a pede posuere nonummy. Integer non velit.
+
+Donec diam neque, vestibulum eget, vulputate ut, ultrices vel, augue. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec pharetra, magna vestibulum aliquet ultrices, erat tortor sollicitudin mi, sit amet lobortis sapien sapien non mi. Integer ac neque.
+
+Duis bibendum. Morbi non quam nec dui luctus rutrum. Nulla tellus.', '2023-02-13', '2022-12-22');
+insert into ARTICLE (title, content, created_at, modified_at) values ('Waterboys', 'Morbi non lectus. Aliquam sit amet diam in magna bibendum imperdiet. Nullam orci pede, venenatis non, sodales sed, tincidunt eu, felis.
+
+Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.', '2022-10-15', '2023-01-28');
+insert into ARTICLE (title, content, created_at, modified_at) values ('No Time for Love', 'Fusce posuere felis sed lacus. Morbi sem mauris, laoreet ut, rhoncus aliquet, pulvinar sed, nisl. Nunc rhoncus dui vel sem.
+
+Sed sagittis. Nam congue, risus semper porta volutpat, quam pede lobortis ligula, sit amet eleifend pede libero quis orci. Nullam molestie nibh in lectus.
+
+Pellentesque at nulla. Suspendisse potenti. Cras in purus eu magna vulputate luctus.', '2022-08-24', '2022-08-06');


### PR DESCRIPTION
#2 

## 현재 굉장히 로우 레벨로 구현

처음부터 다 고려하여 구현하기에는 로직이 꼬일 것 같아 간단하게 구현 후 조금씩 개선하려고 합니다.

1. 전체 게시글 에서 자주 쓰이는 단어 배제 로직 개선
2. 연관 게시글 시 문제점
  - 게시글을 생성하는 시점에 게시글만 연관 게시글 생성 가능
  - 총 게시글이 변함에 따라 연관 게시글이 작동되는 로직의 수치도 변화가 있을 텐데, 현재 이 부분에 있어서 Batch를 구현하지 못했기에 반영할 방법이 없음 -> 로직적 혹은 sudocode로 생각해서 readme에 작성하여 고민의 근거를 남기겠습니다.
  - 현재는 `Controller` 단에서 로직의 flow를 주도 하고 있는데 이렇게 작성 시 transaction 관리에 있어서 불상사 발생할 가능성 있음 
  -> 추후 개선 방법으로는 event를 활용
  -> event 로 구현 시 게시물 생성 시 publish 하여 event 발생 후 연관게시글 설정과 일정 기간에 따라 임의의 event 발생 후 DB 변경 사항에 따른 연관게시글 refresh가 가능하지 않을까 합니다.
 - 빈도 반영 
   -> 머릿속에서는 Map<K,V>로 연관 관계를 가져가서 Key값엔 articleId, Value 에는 Priority 를 반영한 순위를 저장하여 연관 게시글 노출 시 Order By Priority를 구현하려 했습니다.

추후 미비한 부분들 최대한 리팩토링 하고, 구현하지 못했다면 sudocode 혹은 논리적인 문서로 기술해두겠습니다.
